### PR TITLE
Update a8c-ci-toolkit Buildkite plugin to new name and latest version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-  - &bash_cache automattic/bash-cache#v1.3.2: ~
+    - automattic/a8c-ci-toolkit#2.15.0
   # Common environment values to use with the `env` key.
   env: &common_env
     IMAGE_ID: xcode-13


### PR DESCRIPTION
## What

- Update the `bash-cache` Buildkite plugin name to `a8c-ci-toolkit`
- Update the `a8c-ci-toolkit` plugin to version `2.15.0` 

## Testing

Ensure that CI is green and that all checks passed.